### PR TITLE
HTML Acceptance and rejection messages

### DIFF
--- a/routes/user.coffee
+++ b/routes/user.coffee
@@ -104,35 +104,35 @@ module.exports = (app) -> self = new class
               The So Make It web team.
               """
             html: """
-				<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" 
-				"http://www.w3.org/TR/1999/REC-html401-19991224/frameset.dtd">
-				<html>
-				<head>
-				</head>
-				<body>
-				<img src="https://members.somakeit.org.uk/img/header.png" alt="So Make It" />
-				<p>
+				    <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" 
+				    "http://www.w3.org/TR/1999/REC-html401-19991224/frameset.dtd">
+				    <html>
+				    <head>
+				    </head>
+				    <body>
+				    <img src="https://members.somakeit.org.uk/img/header.png" alt="So Make It" />
+				    <p>
                 <b>Hello #{user.fullname} (#{user.username})</b>,<br />
-				<br />
-				</p>
-				<p>
-				We are sorry to inform you that you application to join So Make It has been rejected.<br/>
-				The person who reviewed your application was #{req.session.fullname}, and they gave the following reasons:
-				</p>
-				<p>
-				---<br />
-				#{req.body.message}<br />
-				---<br />
-				</p>
-				<p>
+				    <br />
+				    </p>
+				    <p>
+				    We are sorry to inform you that you application to join So Make It has been rejected.<br/>
+				    The person who reviewed your application was #{req.session.fullname}, and they gave the following reasons:
+				    </p>
+				    <p>
+				    ---<br />
+				    #{req.body.message}<br />
+				    ---<br />
+				    </p>
+				    <p>
                 Kind regards,
-				</p>
-				<p>
-				The So Make It web team
-				</p>
-				</body>
-				</html>
-			  """
+				    </p>
+				    <p>
+				    The So Make It web team
+				    </p>
+				    </body>
+				    </html>
+			      """
             }, (err, res) ->
               if err
                 response.render 'message', {title: "Error", text: "Error sending email: #{err}"}
@@ -165,12 +165,12 @@ module.exports = (app) -> self = new class
           else
             # Approve
             gmail.sendMail {
-               from: "So Make It <web@somakeit.org.uk>"
-               to: user.email
-               bcc: "#{process.env.TRUSTEES_ADDRESS}"
-               subject: "So Make It approval"
-               text: """
-               Hello #{user.fullname} (#{user.username}),
+              from: "So Make It <web@somakeit.org.uk>"
+              to: user.email
+              bcc: "#{process.env.TRUSTEES_ADDRESS}"
+              subject: "So Make It approval"
+              text: """
+              Hello #{user.fullname} (#{user.username}),
 
                 We're happy to inform you that your application to join So Make It was approved by #{req.session.fullname} and you are now on our Register of Members!
 
@@ -186,15 +186,14 @@ module.exports = (app) -> self = new class
 
 				Our opening times can be found at 
 
-				wiki.somakeit.org.uk
-
+https://wiki.somakeit.org.uk/wiki/Opening_Hours
 
 
                 Kind regards,
 
                 The So Make It web team.
-               """
-               html: """
+                """
+              html: """
 				<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" 
 				"http://www.w3.org/TR/1999/REC-html401-19991224/frameset.dtd">
 				<html>
@@ -218,7 +217,7 @@ module.exports = (app) -> self = new class
 				Sign up for the wiki <a href="https://wiki.somakeit.org.uk/index.php5?title=Special:UserLogin&type=signup">here</a> to add your project, or just do some general updates (This is not yet integrated into the members area, but if you want to help out with that <a href="https://github.com/so-make-it/members-area")
 </p>
 <p>
-				Our opening times can be found <a href="http://wiki.somakeit.org.uk">on our wiki</a>
+				Our opening times can be found <a href="https://wiki.somakeit.org.uk/wiki/Opening_Hours">on our wiki</a>
 </p>
 <p>
 <br />
@@ -229,7 +228,7 @@ module.exports = (app) -> self = new class
 				</p>
 				</body>
 				</html>
-				"""
+                ""
               }, (err, res) ->
                 if err
                   response.render 'message', {title: "Error", text: "Error sending email: #{err}"}

--- a/routes/user.coffee
+++ b/routes/user.coffee
@@ -228,7 +228,7 @@ https://wiki.somakeit.org.uk/wiki/Opening_Hours
 				</p>
 				</body>
 				</html>
-                ""
+                """
               }, (err, res) ->
                 if err
                   response.render 'message', {title: "Error", text: "Error sending email: #{err}"}

--- a/routes/user.coffee
+++ b/routes/user.coffee
@@ -144,9 +144,21 @@ module.exports = (app) -> self = new class
 
                 We're happy to inform you that your application to join So Make It was approved by #{req.session.fullname} and you are now on our Register of Members!
 
-                Welcome! Why not read more about the makerspace on our wiki?
+                Welcome aboard! 
+				
+				Why not say hi on IRC, put your project on our wiki, and come start making things!
 
-                http://wiki.somakeit.org.uk/
+				We can be found on IRC at irc.freenode.net #southackton and #somakeit
+
+				Sign up for the wiki at
+				
+				https://wiki.somakeit.org.uk/index.php5?title=Special:UserLogin&type=signup
+
+				Our opening times can be found at 
+
+				wiki.somakeit.org.uk
+
+
 
                 Kind regards,
 

--- a/routes/user.coffee
+++ b/routes/user.coffee
@@ -214,7 +214,7 @@ https://wiki.somakeit.org.uk/wiki/Opening_Hours
 				We can be found on IRC at irc.freenode.net #southackton and #somakeit
 </p>
 <p>
-				Sign up for the wiki <a href="https://wiki.somakeit.org.uk/index.php5?title=Special:UserLogin&type=signup">here</a> to add your project, or just do some general updates (This is not yet integrated into the members area, but if you want to help out with that <a href="https://github.com/so-make-it/members-area")
+				Sign up for the wiki <a href="https://wiki.somakeit.org.uk/index.php5?title=Special:UserLogin&type=signup">here</a> to add your project, or just do some general updates (This is not yet integrated into the members area, but if you want to help out with that... <a href="https://github.com/so-make-it/members-area">go for it</a>)
 </p>
 <p>
 				Our opening times can be found <a href="https://wiki.somakeit.org.uk/wiki/Opening_Hours">on our wiki</a>

--- a/routes/user.coffee
+++ b/routes/user.coffee
@@ -164,6 +164,27 @@ module.exports = (app) -> self = new class
 
                 The So Make It web team.
                 """
+			html: """
+
+                Hello #{user.fullname} (#{user.username}),
+
+                We're happy to inform you that your application to join So Make It was approved by #{req.session.fullname} and you are now on our Register of Members!
+
+                Welcome aboard! 
+				
+				Why not say hi on IRC, put your project on our wiki, and come start making things!
+
+				We can be found on IRC at irc.freenode.net #southackton and #somakeit
+
+				Sign up for the wiki <a href="https://wiki.somakeit.org.uk/index.php5?title=Special:UserLogin&type=signup">here</a> to add your project, or just help add knowledge.
+
+				Our opening times can be found <a href="http://wiki.somakeit.org.uk">on our wiki</a>
+
+
+
+                Kind regards,
+
+			"""
               }, (err, res) ->
                 if err
                   response.render 'message', {title: "Error", text: "Error sending email: #{err}"}

--- a/routes/user.coffee
+++ b/routes/user.coffee
@@ -135,12 +135,12 @@ module.exports = (app) -> self = new class
           else
             # Approve
             gmail.sendMail {
-              from: "So Make It <web@somakeit.org.uk>"
-              to: user.email
-              bcc: "#{process.env.TRUSTEES_ADDRESS}"
-              subject: "So Make It approval"
-              text: """
-                Hello #{user.fullname} (#{user.username}),
+               from: "So Make It <web@somakeit.org.uk>"
+               to: user.email
+               bcc: "#{process.env.TRUSTEES_ADDRESS}"
+               subject: "So Make It approval"
+               text: """
+               Hello #{user.fullname} (#{user.username}),
 
                 We're happy to inform you that your application to join So Make It was approved by #{req.session.fullname} and you are now on our Register of Members!
 
@@ -163,28 +163,43 @@ module.exports = (app) -> self = new class
                 Kind regards,
 
                 The So Make It web team.
-                """
-			html: """
-
-                Hello #{user.fullname} (#{user.username}),
-
-                We're happy to inform you that your application to join So Make It was approved by #{req.session.fullname} and you are now on our Register of Members!
-
-                Welcome aboard! 
-				
-				Why not say hi on IRC, put your project on our wiki, and come start making things!
-
+               """
+               html: """
+				<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" 
+				"http://www.w3.org/TR/1999/REC-html401-19991224/frameset.dtd">
+				<html>
+				<head>
+				</head>
+				<body>
+				<img src="https://members.somakeit.org.uk/img/header.png" alt="So Make It" />
+				<p>
+                <b>Hello #{user.fullname} (#{user.username})</b>,<br />
+				<br />
+                We're happy to inform you that your application to join So Make It was <b style="color:green">approved</b> by #{req.session.fullname} and you are now on our Register of Members!
+				</p>
+                <p>
+				Welcome aboard! 
+				</p>
+				<p>
+				Why not say hi on IRC, put your project on our wiki, and come start making things!<br />
 				We can be found on IRC at irc.freenode.net #southackton and #somakeit
-
-				Sign up for the wiki <a href="https://wiki.somakeit.org.uk/index.php5?title=Special:UserLogin&type=signup">here</a> to add your project, or just help add knowledge.
-
+</p>
+<p>
+				Sign up for the wiki <a href="https://wiki.somakeit.org.uk/index.php5?title=Special:UserLogin&type=signup">here</a> to add your project, or just do some general updates (This is not yet integrated into the members area, but if you want to help out with that <a href="https://github.com/so-make-it/members-area"> go for it!</a>)
+</p>
+<p>
 				Our opening times can be found <a href="http://wiki.somakeit.org.uk">on our wiki</a>
-
-
-
+</p>
+<p>
+<br />
                 Kind regards,
-
-			"""
+				</p>
+				<p>
+				The So Make It web team
+				</p>
+				</body>
+				</html>
+				"""
               }, (err, res) ->
                 if err
                   response.render 'message', {title: "Error", text: "Error sending email: #{err}"}

--- a/routes/user.coffee
+++ b/routes/user.coffee
@@ -103,6 +103,36 @@ module.exports = (app) -> self = new class
 
               The So Make It web team.
               """
+            html: """
+				<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" 
+				"http://www.w3.org/TR/1999/REC-html401-19991224/frameset.dtd">
+				<html>
+				<head>
+				</head>
+				<body>
+				<img src="https://members.somakeit.org.uk/img/header.png" alt="So Make It" />
+				<p>
+                <b>Hello #{user.fullname} (#{user.username})</b>,<br />
+				<br />
+				</p>
+				<p>
+				We are sorry to inform you that you application to join So Make It has been rejected.<br/>
+				The person who reviewed your application was #{req.session.fullname}, and they gave the following reasons:
+				</p>
+				<p>
+				---<br />
+				#{req.body.message}<br />
+				---<br />
+				</p>
+				<p>
+                Kind regards,
+				</p>
+				<p>
+				The So Make It web team
+				</p>
+				</body>
+				</html>
+			  """
             }, (err, res) ->
               if err
                 response.render 'message', {title: "Error", text: "Error sending email: #{err}"}
@@ -185,7 +215,7 @@ module.exports = (app) -> self = new class
 				We can be found on IRC at irc.freenode.net #southackton and #somakeit
 </p>
 <p>
-				Sign up for the wiki <a href="https://wiki.somakeit.org.uk/index.php5?title=Special:UserLogin&type=signup">here</a> to add your project, or just do some general updates (This is not yet integrated into the members area, but if you want to help out with that <a href="https://github.com/so-make-it/members-area"> go for it!</a>)
+				Sign up for the wiki <a href="https://wiki.somakeit.org.uk/index.php5?title=Special:UserLogin&type=signup">here</a> to add your project, or just do some general updates (This is not yet integrated into the members area, but if you want to help out with that <a href="https://github.com/so-make-it/members-area")
 </p>
 <p>
 				Our opening times can be found <a href="http://wiki.somakeit.org.uk">on our wiki</a>

--- a/routes/user.coffee
+++ b/routes/user.coffee
@@ -214,7 +214,7 @@ https://wiki.somakeit.org.uk/wiki/Opening_Hours
 				We can be found on IRC at irc.freenode.net #southackton and #somakeit
 </p>
 <p>
-				Sign up for the wiki <a href="https://wiki.somakeit.org.uk/index.php5?title=Special:UserLogin&type=signup">here</a> to add your project, or just do some general updates (This is not yet integrated into the members area, but if you want to help out with that... <a href="https://github.com/so-make-it/members-area">go for it</a>)
+        Sign up for the wiki <a href="https://wiki.somakeit.org.uk/index.php5?title=Special:UserLogin&type=signup">here</a> to add your project, or just do some general updates (This is not yet integrated into the members area, but if you want to help out with that... <a href="https://github.com/so-make-it/members-area">go for it</a>)
 </p>
 <p>
 				Our opening times can be found <a href="https://wiki.somakeit.org.uk/wiki/Opening_Hours">on our wiki</a>


### PR DESCRIPTION
I have added HTML variants of the acceptance and rejection emails sent out when members are approved/rejected. 
In addition, the wording of the acceptance email has been updated slightly. This includes some additional links to the wiki sign up and the SMI github. It also adds a SMI banner graphic to the top of the emails.
